### PR TITLE
fixing issue with opencv + replacing sys.exit with exception

### DIFF
--- a/utilsChecker.py
+++ b/utilsChecker.py
@@ -821,7 +821,7 @@ def synchronizeVideos(CameraDirectories, trialRelativePath, pathPoseDetector,
         key2D, confidence = loadPklVideo(
             ppPklPath, videoFullPath, imageBasedTracker=imageBasedTracker,
             poseDetector=poseDetector,confidenceThresholdForBB=0.3)
-        thisVideo = cv2.VideoCapture(videoFullPath[:-4] + '_rotated.avi')
+        thisVideo = cv2.VideoCapture(videoFullPath.replace('.mov', '_rotated.avi'))
         frameRate = np.round(thisVideo.get(cv2.CAP_PROP_FPS))        
         if key2D.shape[1] == 0 and confidence.shape[1] == 0:
             camsToExclude.append(camName)
@@ -1483,7 +1483,7 @@ def trackKeypointBox(videoPath,bbStart,allPeople,allBoxes,dataOut,frameStart = 0
 
     # initiate video capture
     # Read video
-    video = cv2.VideoCapture(videoPath)
+    video = cv2.VideoCapture(videoPath.replace('.mov', '_rotated.avi'))
     nFrames = allBoxes[0].shape[0]
     
     # Read desiredFrames.
@@ -1491,7 +1491,7 @@ def trackKeypointBox(videoPath,bbStart,allPeople,allBoxes,dataOut,frameStart = 0
     ok, frame = video.read()
     if not ok:
         print('Cannot read video file')
-        sys.exit()
+        raise Exception('Cannot read video file')
         
     imageSize = (frame.shape[0],frame.shape[1])
     justStarted = True
@@ -1569,15 +1569,14 @@ def trackBoundingBox(videoPath,bbStart,allPeople,allBoxes,dataOut,frameStart = 0
     frameNum = frameStart
     
     # Read video
-    video = cv2.VideoCapture(videoPath)
+    video = cv2.VideoCapture(videoPath.replace('.mov', '_rotated.avi'))
     nFrames = allBoxes[0].shape[0]
 
     # Read desiredFrames.
     video.set(1, frameNum)
     ok, frame = video.read()
     if not ok:
-        print('Cannot read video file')
-        sys.exit()
+        raise Exception('Cannot read video file')
          
     # Initialize tracker with first frame and bounding box
     try:
@@ -2525,7 +2524,7 @@ def triangulateMultiviewVideo(CameraParamDict,keypointDict,imageScaleFactor=1,
             
             # get frame rate and assume all the same for sync'd videos
             if iCam==0: 
-                thisVideo = cv2.VideoCapture(inputPath)
+                thisVideo = cv2.VideoCapture(inputPath.replace('.mov', '_rotated.avi'))
                 frameRate = np.round(thisVideo.get(cv2.CAP_PROP_FPS))
                 thisVideo.release()
             


### PR DESCRIPTION
@suhlrich FYI, I will merge tomorrow and update the workers.

Two fixes:

- using opencv with the .avi video instead of the .mov video. For some reasons it sometimes fails.
- raising exception instead of using sys.exit, that way we get the pickles in django and can debug

Tests I have done:

- Case that failed is now working
- Case that worked is giving exact same kinematics
- Tried locally and on server
