### PR TITLE
stop machine when pose detection is timing out

### DIFF
--- a/utilsDetector.py
+++ b/utilsDetector.py
@@ -202,15 +202,19 @@ def runOpenPoseCMD(pathOpenPose, resolutionPoseDetection, cameraDirectory,
                     break
                 
                 if start + 60*30 < time.time():
-                    raise Exception("OpenPose processing timeout")
+                    raise Exception("Pose detection timed out. This is unlikely to be your fault, please report this issue on the forum. You can proceed with your data collection (videos are uploaded to the server) and later reprocess errored trials.", 'timeout - openpose')
                 
                 time.sleep(0.1)
             
             # copy /data/output to openposeJsonDir
             os.system("cp /data/output_openpose/* {cameraDirectory}/{openposeJsonDir}/".format(cameraDirectory=cameraDirectory, openposeJsonDir=openposeJsonDir))
-        except:
-            exception = "Pose detection failed. Verify your setup and try again. Visit https://www.opencap.ai/best-pratices to learn more about data collection and https://www.opencap.ai/troubleshooting for potential causes for a failed neutral pose."
-            raise Exception(exception, exception)
+        
+        except Exception as e:
+            if len(e.args) == 2: # specific exception
+                raise Exception(e.args[0], e.args[1])
+            elif len(e.args) == 1: # generic exception
+                exception = "Pose detection failed. Verify your setup and try again. Visit https://www.opencap.ai/best-pratices to learn more about data collection and https://www.opencap.ai/troubleshooting for potential causes for a failed neutral pose."
+                raise Exception(exception, exception)   
             
     elif pathOpenPose == "docker":
         
@@ -309,20 +313,22 @@ def runMMposeVideo(
                         break
                     
                     if start + 60*30 < time.time():
-                        raise Exception("mmpose processing timeout")
-                    
+                        raise Exception("Pose detection timed out. This is unlikely to be your fault, please report this issue on the forum. You can proceed with your data collection (videos are uploaded to the server) and later reprocess errored trials.", 'timeout - hrnet')
+                
                     time.sleep(0.1)
-            
+                      
                 # copy /data/output to pathOutputPkl
                 os.system("cp /data/output_mmpose/* {pathOutputPkl}/".format(pathOutputPkl=pathOutputPkl))            
                 pkl_path_tmp = os.path.join(pathOutputPkl, 'human.pkl')            
                 os.rename(pkl_path_tmp, pklPath)
-            except:
-                exception = "Pose detection failed. Verify your setup and try again. Visit https://www.opencap.ai/best-pratices to learn more about data collection and https://www.opencap.ai/troubleshooting for potential causes for a failed neutral pose."
-                raise Exception(exception, exception)
             
-        else:
-            
+            except Exception as e:
+                if len(e.args) == 2: # specific exception
+                    raise Exception(e.args[0], e.args[1])
+                elif len(e.args) == 1: # generic exception
+                    exception = "Pose detection failed. Verify your setup and try again. Visit https://www.opencap.ai/best-pratices to learn more about data collection and https://www.opencap.ai/troubleshooting for potential causes for a failed neutral pose."
+                    raise Exception(exception, exception)            
+        else:           
             c_path = os.path.dirname(os.path.abspath(__file__))
             sys.path.append(os.path.join(c_path, 'mmpose'))
             from utilsMMpose import detection_inference, pose_inference

--- a/utilsServer.py
+++ b/utilsServer.py
@@ -143,7 +143,7 @@ def processTrial(session_id, trial_id, trial_type = 'dynamic',
             error_msg['error_msg_dev'] = e.args[1]
             _ = requests.patch(trial_url, data={"meta": json.dumps(error_msg)},
                    headers = {"Authorization": "Token {}".format(API_TOKEN)})
-            raise Exception('Static trial failed')
+            raise Exception('Static trial failed', e.args[0], e.args[1])
         
         if not hasWritePermissions:
             print('You are not the owner of this session, so do not have permission to write results to database.')
@@ -232,7 +232,7 @@ def processTrial(session_id, trial_id, trial_type = 'dynamic',
             error_msg['error_msg_dev'] = e.args[1]
             _ = requests.patch(trial_url, data={"meta": json.dumps(error_msg)},
                    headers = {"Authorization": "Token {}".format(API_TOKEN)})   
-            raise Exception('Dynamic trial failed.\n' + error_msg['error_msg_dev'])
+            raise Exception('Dynamic trial failed.\n' + error_msg['error_msg_dev'], e.args[0], e.args[1])
         
         if not hasWritePermissions:
             print('You are not the owner of this session, so do not have permission to write results to database.')


### PR DESCRIPTION
@suhlrich my machine (and maybe others) is sometimes failing. The symptom is mmpose not starting and pose detection timing out. Problem is that it keeps running, and will keep failing trials. With this PR, I bring up the error message and kill the worker in app.py if it is the particular error message. not sure it is the best way, but it works as expected. The [if statement](https://github.com/stanfordnmbl/opencap-core/blob/issue_132/app.py#L103) is based on the error message text, which is not fantastic but it works with minimal change.