### PR TITLE
fix bug data reprocessing

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -553,7 +553,7 @@ def downloadAndSwitchCalibrationFromDjango(session_id,session_path,calibTrialID 
        
     calibURLs = {t['device_id']:t['media'] for t in trial['results'] if t['tag'] == 'calibration_parameters_options'}
     
-    if 'meta' in trial.keys() and trial['meta'] is not None and 'calibration' in trial['meta'].keys():
+    if 'meta' in trial.keys() and trial['meta'] is not None and 'calibration' in trial['meta'].keys() and trial['meta']['calibration']:
         calibDict = trial['meta']['calibration']
     else:
         print('No metadata for camera switching. Using first solution.')


### PR DESCRIPTION
@suhlrich I was trying to reprocess data, but was running into an issue [here](https://github.com/stanfordnmbl/opencap-core/blob/main/main.py#L335-L337) because `calibrationOptions` was an empty dict (see screenshot below). Not sure, maybe someone corrupted it when people still had the possibility to push to our session. I believe this PR solves this particular case by requiring something to be within the dict. Let me know what you think.

![image](https://github.com/stanfordnmbl/opencap-core/assets/19328993/5e301e18-9a6a-4e11-9807-2c975d4649b0)
