### PR TITLE
Trying to understand why test is crashing sporadically

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -847,11 +847,12 @@ def postFileToTrial(filePath,trial_id,tag,device_id):
         
     # get S3 link
     data = {'fileName':os.path.split(filePath)[1]}
-    r = requests.get(API_URL + "sessions/null/get_presigned_url/",data=data).json()
+    r = requests.get(API_URL + "sessions/null/get_presigned_url/",data=data)
+    r_json = r.json()
     
     # upload to S3
     files = {'file': open(filePath, 'rb')}
-    requests.post(r['url'], data=r['fields'],files=files)   
+    requests.post(r_json['url'], data=r_json['fields'],files=files)   
     files["file"].close()
 
     # post link to and data to results   
@@ -859,14 +860,17 @@ def postFileToTrial(filePath,trial_id,tag,device_id):
         "trial": trial_id,
         "tag": tag,
         "device_id" : device_id,
-        "media_url" : r['fields']['key']
+        "media_url" : r_json['fields']['key']
     }
     
     rResult = requests.post(API_URL + "results/", data=data,
                   headers = {"Authorization": "Token {}".format(API_TOKEN)})
     
     if rResult.status_code != 201:
-        print('server response was + ' + str(r.status_code))
+        print('server get response was', r.status_code)
+        print('server post response was', rResult.status_code)
+        print(rResult.json())
+        print('lets make it crash: server response was + ' + str(r_json.status_code))
     else:
         print('Result posted to S3.')
     


### PR DESCRIPTION
@suhlrich and @AlbertoCasasOrtiz 
Now and then, the test is crashing with this error message:

> mobilecap_1  |   File "/workspace/utilsServer.py", line 460, in runTestSession
mobilecap_1  |     processTrial(trial["session"], trial_id, trial_type='static', isDocker=isDocker)
mobilecap_1  |   File "/workspace/utilsServer.py", line 155, in processTrial
mobilecap_1  |     writeMediaToAPI(API_URL,video_path,trial_id, tag='video-sync',deleteOldMedia=True)
mobilecap_1  |   File "/workspace/utils.py", line 156, in writeMediaToAPI
mobilecap_1  |     postFileToTrial(fullpath,trial_id,tag,device_id)
mobilecap_1  |   File "/workspace/utils.py", line 869, in postFileToTrial
mobilecap_1  |     print('server response was + ' + str(r.status_code))
mobilecap_1  | AttributeError: 'dict' object has no attribute 'status_code'
mobilecap_1  |
mobilecap_1  | During handling of the above exception, another exception occurred:
mobilecap_1  |
mobilecap_1  | Traceback (most recent call last):
mobilecap_1  |   File "app.py", line 35, in <module>
mobilecap_1  |     runTestSession(isDocker=isDocker)
mobilecap_1  |   File "/workspace/utilsServer.py", line 466, in runTestSession
mobilecap_1  |     raise Exception('Failed status check. Stopped.')
mobilecap_1  | Exception: Failed status check. Stopped.

There are two things here. First, it actually crashes because r has no status code after being converted into a json. That's an easy fix. Second, the important question is why `rResult.status_code != 201` is not `True`. With this PR, we add a few print statements to try to understand what is going on.