### PR TITLE
increase pelvis rotation bounds

### DIFF
--- a/opensimPipeline/Models/LaiUhlrich2022.osim
+++ b/opensimPipeline/Models/LaiUhlrich2022.osim
@@ -3177,7 +3177,7 @@
 							<!--The speed value of this coordinate before any value has been set. Rotational coordinate value is in rad/s and Translational in m/s.-->
 							<default_speed_value>0</default_speed_value>
 							<!--The minimum and maximum values that the coordinate can range between. Rotational coordinate range in radians and Translational in meters.-->
-							<range>-6.283185307179586 6.283185307179586</range>
+							<range>-100 100</range>
 							<!--Flag indicating whether or not the values of the coordinates should be limited to the range, above.-->
 							<clamped>true</clamped>
 							<!--Flag indicating whether or not the values of the coordinates should be constrained to the current (e.g. default) value, above.-->

--- a/opensimPipeline/Models/LaiUhlrich2022_shoulder.osim
+++ b/opensimPipeline/Models/LaiUhlrich2022_shoulder.osim
@@ -3257,7 +3257,7 @@
 							<!--The speed value of this coordinate before any value has been set. Rotational coordinate value is in rad/s and Translational in m/s.-->
 							<default_speed_value>0</default_speed_value>
 							<!--The minimum and maximum values that the coordinate can range between. Rotational coordinate range in radians and Translational in meters.-->
-							<range>-6.283185307179586 6.283185307179586</range>
+							<range>-100 100</range>
 							<!--Flag indicating whether or not the values of the coordinates should be limited to the range, above.-->
 							<clamped>true</clamped>
 							<!--Flag indicating whether or not the values of the coordinates should be constrained to the current (e.g. default) value, above.-->


### PR DESCRIPTION
-360 - 360 causes problems with more free-form walking

Tested on one trial and it does start close to 0 and was continuous.