### PR TITLE
Remove model constraints (and the rest) to make IK faster

### DIFF
--- a/main.py
+++ b/main.py
@@ -605,7 +605,7 @@ def main(sessionName, trialName, trial_id, cameras_to_use=['all'],
                 # Run IK tool. 
                 logging.info('Running Inverse Kinematics')
                 try:
-                    pathOutputIK = runIKTool(
+                    pathOutputIK, pathModelIK = runIKTool(
                         pathGenericSetupFile4IK, pathScaledModel, 
                         pathTRCFile4IK, outputIKDir)
                 except Exception as e:
@@ -623,7 +623,7 @@ def main(sessionName, trialName, trial_id, cameras_to_use=['all'],
         os.makedirs(outputJsonVisDir,exist_ok=True)
         outputJsonVisPath = os.path.join(outputJsonVisDir,
                                          trialName + '.json')
-        generateVisualizerJson(pathScaledModel, pathOutputIK,
+        generateVisualizerJson(pathModelIK, pathOutputIK,
                                outputJsonVisPath, 
                                vertical_offset=vertical_offset)  
         

--- a/utilsOpenSim.py
+++ b/utilsOpenSim.py
@@ -171,32 +171,26 @@ def runIKTool(pathGenericSetupFile, pathScaledModel, pathTRCFile,
     model = opensim.Model(pathScaledModel)
     # Remove all actuators.                                         
     forceSet = model.getForceSet()
-    i = 0
-    while i < forceSet.getSize():
-        forceSet.remove(i)
-    # Remove all constraints.
+    forceSet.setSize(0)
+    # Remove patellofemoral constraints.
     constraintSet = model.getConstraintSet()
-    i = 0
-    while i < constraintSet.getSize():
-        constraintSet.remove(i)        
+    patellofemoral_constraints = [
+        'patellofemoral_knee_angle_r_con', 'patellofemoral_knee_angle_l_con']
+    for patellofemoral_constraint in patellofemoral_constraints:
+        i = constraintSet.getIndex(patellofemoral_constraint, 0)
+        constraintSet.remove(i)       
     # Remove patella bodies.
     bodySet = model.getBodySet()
     patella_bodies = ['patella_r', 'patella_l']
     for patella in patella_bodies:
-        for i in range(bodySet.getSize()):        
-            c_body = bodySet.get(i).getName()
-            if c_body == patella:
-                bodySet.remove(i)
-                break
+        i = bodySet.getIndex(patella, 0)
+        bodySet.remove(i)
     # Remove patellofemoral joints.
     jointSet = model.getJointSet()
     patellofemoral_joints = ['patellofemoral_r', 'patellofemoral_l']
     for patellofemoral in patellofemoral_joints:
-        for i in range(jointSet.getSize()):
-            c_joint = jointSet.get(i).getName()
-            if c_joint == patellofemoral:
-                jointSet.remove(i)
-                break
+        i = jointSet.getIndex(patellofemoral, 0)
+        jointSet.remove(i)
     # Print the model to a new file.
     model.finalizeConnections
     model.initSystem()


### PR DESCRIPTION
@suhlrich @carmichaelong 

The patella constraints make IK super slow; by removing them we can get some massive speed up. Since the patella should not be defining the IK solution at all (no markers attached to the patella), it should be fine to create a temporary model without the patella bodies, the patellofemoral joints, and the patella constraints and then run IK with that model. This is what this PR is implementing. Note that there are muscles attached to the patella, I therefore also removed all muscles (no involved in IK):

I did a fair bit of testing:
- 60s trial (60 Hz) ~ 3600 frames
    - With constraints: IK time - 218s
    - Without constraints: IK time - 7s
- running trial 1242 frames
    - With constraints: IK time - 64s
    - Without constraints: IK time - 8s

When I compare the resulting IK results, the angles are within 1deg. You can run the `compare.py` script in the attached folder to appreciate the differences for running. Interesting fact 1: the largest differences are for the pro_sup angles. Intersting fact 2: with constraints the mtp angle is set to 7.5deg, without constraints tht mtp angle is set to 0deg. There are no markers attached to the mtp, so 0deg seems more expected. The side benefit of this PR is that we no longer get this knee_angle_beta columns in the mot file, so we no longer see it in the dashboard.

[test.zip](https://github.com/user-attachments/files/16059325/test.zip)