### PR TITLE
Exclude camera post overlap selection if bad data

### DIFF
--- a/utilsChecker.py
+++ b/utilsChecker.py
@@ -1037,12 +1037,9 @@ def synchronizeVideoKeypoints(keypointList, confidenceList,
     allMarkerList = [p[:,idxStart:idxEnd] for p in allMarkerList]
     confSyncList= [c[:,idxStart:idxEnd] for c in confidenceList]
     
-    
+    # We do this again, since it might have changed after finding the overlap period.
     keypointList = list(keypointList)
     confidenceList = list(confidenceList)
-    
-    # We do this check again, since it might have have changed after finding
-    # the overlap period.
     badCamerasOverlap = []
     for icam, conf in enumerate(confSyncList):
         if np.mean(conf) <= 0.01: # Looser than sum=0 to disregard very few frames with data
@@ -1069,7 +1066,6 @@ def synchronizeVideoKeypoints(keypointList, confidenceList,
     # to use. Input right and left ankle marker speeds. Gait should be
     # detected for all cameras (all but one camera is > 2 cameras) for the
     # trial to be considered a gait trial.
-
     try:
         isGait = detectGaitAllVideos(mkrSpeedList,allMarkerList,confSyncList,markers4Ankles,sampleFreq)
     except:


### PR DESCRIPTION
If the person tracking didn't really work, we might end up with a camera with only 0s after the overlap period has been selected. This would cause the gait algo to fail because of some division by 0 and therefore sync would fail overall. This PR does two things:

1) It encapsulates the gait detection algo into a try statement such that it would move forward regardless
2) It kicks out a camera post overlap selection if it contains only a bunch of 0s

Tested on three trials from the ACL study that were failing because person tracking had failed for 1/3 camera and it worked fine. Touching `synchronizeVideoKeypoints` is daunting so take a close look at what I did, I don't think I broke anything.