### PR TITLE
Error 2 hrnet detection pose

### DIFF
--- a/utilsChecker.py
+++ b/utilsChecker.py
@@ -820,8 +820,11 @@ def synchronizeVideos(CameraDirectories, trialRelativePath, pathPoseDetector,
         openposePklDir = os.path.join(outputPklFolder, trialName)
         pathOutputPkl = os.path.join(cameraDirectory, openposePklDir)
         ppPklPath = os.path.join(pathOutputPkl, trialPrefix+'_rotated_pp.pkl')
+        # Check if neutral.
+        components = ppPklPath.split(os.sep)
+        is_neutral = 'neutral' in components
         # Check if the pkl file exists before trying to use it.
-        if not os.path.exists(ppPklPath):
+        if not is_neutral and not os.path.exists(ppPklPath):
             print(f"{ppPklPath} does not exist. Excluding {camName}.")
             camsToExclude.append(camName)
             continue

--- a/utilsChecker.py
+++ b/utilsChecker.py
@@ -824,9 +824,13 @@ def synchronizeVideos(CameraDirectories, trialRelativePath, pathPoseDetector,
         components = ppPklPath.split(os.sep)
         is_neutral = 'neutral' in components
         # Check if the pkl file exists before trying to use it.
-        if not is_neutral and not os.path.exists(ppPklPath):
-            print(f"{ppPklPath} does not exist. Excluding {camName}.")
-            camsToExclude.append(camName)
+        if not os.path.exists(ppPklPath):
+            if is_neutral:
+                exception = "Pose detection failed for at least one camera. Verify your setup and try again. Visit https://www.opencap.ai/best-pratices to learn more about data collection and https://www.opencap.ai/troubleshooting for potential causes for a failed neutral pose."
+                raise Exception(exception, exception)
+            else:
+                print(f"{ppPklPath} does not exist. Excluding {camName}.")
+                camsToExclude.append(camName)
             continue
         key2D, confidence = loadPklVideo(
             ppPklPath, videoFullPath, imageBasedTracker=imageBasedTracker,

--- a/utilsChecker.py
+++ b/utilsChecker.py
@@ -820,12 +820,18 @@ def synchronizeVideos(CameraDirectories, trialRelativePath, pathPoseDetector,
         openposePklDir = os.path.join(outputPklFolder, trialName)
         pathOutputPkl = os.path.join(cameraDirectory, openposePklDir)
         ppPklPath = os.path.join(pathOutputPkl, trialPrefix+'_rotated_pp.pkl')
+        # Check if the pkl file exists before trying to use it.
+        if not os.path.exists(ppPklPath):
+            print(f"{ppPklPath} does not exist. Excluding {camName}.")
+            camsToExclude.append(camName)
+            continue
         key2D, confidence = loadPklVideo(
             ppPklPath, videoFullPath, imageBasedTracker=imageBasedTracker,
             poseDetector=poseDetector,confidenceThresholdForBB=0.3)
         thisVideo = cv2.VideoCapture(videoFullPath.replace('.mov', '_rotated.avi'))
         frameRate = np.round(thisVideo.get(cv2.CAP_PROP_FPS))        
         if key2D.shape[1] == 0 and confidence.shape[1] == 0:
+            print(f"Excluding {camName}.")
             camsToExclude.append(camName)
         else:
             pointList.append(key2D)

--- a/utilsDetector.py
+++ b/utilsDetector.py
@@ -37,19 +37,39 @@ def runPoseDetector(CameraDirectories, trialRelativePath, pathPoseDetector,
                                              trialRelativePath)
     extension = getVideoExtension(pathVideoWithoutExtension)            
     trialRelativePath += extension
-        
+
+    successful_cams = 0  # Counter for successful cameras
+    last_exception = None  # To store the last exception
+
     for camName in CameraDirectories_selectedCams:
         cameraDirectory = CameraDirectories_selectedCams[camName]
         print('Running {} for {}'.format(poseDetector, camName))
-        if poseDetector == 'OpenPose':
-            runOpenPoseVideo(
-                cameraDirectory,trialRelativePath,pathPoseDetector, trialName,
-                resolutionPoseDetection=resolutionPoseDetection,
-                generateVideo=generateVideo)
-        elif poseDetector == 'mmpose':
-            runMMposeVideo(
-                cameraDirectory,trialRelativePath,pathPoseDetector, trialName,
-                generateVideo=generateVideo, bbox_thr=bbox_thr)
+
+        try:
+            if poseDetector == 'OpenPose':
+                runOpenPoseVideo(
+                    cameraDirectory, trialRelativePath, pathPoseDetector, trialName,
+                    resolutionPoseDetection=resolutionPoseDetection,
+                    generateVideo=generateVideo)
+                successful_cams += 1
+            elif poseDetector == 'mmpose':
+                runMMposeVideo(
+                    cameraDirectory, trialRelativePath, pathPoseDetector, trialName,
+                    generateVideo=generateVideo, bbox_thr=bbox_thr)
+                successful_cams += 1
+        except Exception as e:
+            print(f"Exception for {camName}: {e}")
+            last_exception = e
+
+    # After the loop, decide based on the successful count
+    if successful_cams == 0:
+        print("No cameras succeeded.")
+        raise last_exception
+    elif successful_cams == 1:
+        print("Only 1 camera succeeded.")
+        raise last_exception
+    else:
+        print(f"At least 2 cameras succeeded ({successful_cams}). Continuing execution.")
             
     return extension
             
@@ -323,7 +343,7 @@ def runMMposeVideo(
                 if os.path.exists(pkl_path_tmp):
                     os.rename(pkl_path_tmp, pklPath)
                 else:
-                    raise FileNotFoundError(
+                    raise Exception(
                         "We could not detect any pose in your video. Please verify that the subject is correctly in front of the camera.", 'missing file - hrnet'
                     )
             except Exception as e:

--- a/utilsDetector.py
+++ b/utilsDetector.py
@@ -324,7 +324,7 @@ def runMMposeVideo(
                     os.rename(pkl_path_tmp, pklPath)
                 else:
                     raise FileNotFoundError(
-                        "We could not detect any pose in your video. Please verify that the subject is correctly in front of the camera."
+                        "We could not detect any pose in your video. Please verify that the subject is correctly in front of the camera.", 'missing file - hrnet'
                     )
             except Exception as e:
                 if len(e.args) == 2: # specific exception


### PR DESCRIPTION
Fixes cases mentioned by @antoinefalisse in #219.

Now, neutral trial always requires the same number of cameras as calibration trial, and dynamic trial works properly with at least 2 cameras seeing the subject.

I've detected that if a phone is directly disconnected (battery died or Wi-Fi disconnected), it will not work as it will complain about not all expected phones uploading videos.