### PR TITLE
Use settings framerate for metadata updates

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,34 @@
+import os
+import sys
+from unittest.mock import Mock, patch
+
+
+thisDir = os.path.dirname(os.path.realpath(__file__))
+repoDir = os.path.abspath(os.path.join(thisDir,'../'))
+sys.path.append(repoDir)
+from utils import changeSessionMetadata
+
+
+@patch('utils.getTrialJson')
+@patch('utils.getNeutralTrialID')
+@patch('utils.makeRequestWithRetry')
+@patch('utils.getSessionJson')
+def test_change_session_metadata_uses_settings_framerate_for_filterfrequency(
+        mock_get_session, mock_make_request, mock_get_neutral, mock_get_trial):
+    mock_get_session.return_value = {
+        'meta': {
+            'settings': {
+                'framerate': 240,
+            },
+        },
+    }
+    mock_make_request.return_value = Mock(status_code=200)
+    mock_get_neutral.return_value = 'neutral-id'
+    mock_get_trial.return_value = {
+        'results': [],
+    }
+
+    changeSessionMetadata(['session-id'], {'filterfrequency': 100})
+
+    patched_meta = mock_make_request.call_args.kwargs['data']['meta']
+    assert '"filterfrequency": "100"' in patched_meta

--- a/utils.py
+++ b/utils.py
@@ -980,10 +980,8 @@ def changeSessionMetadata(session_ids,newMetaDict):
         existingMeta = session['meta']
         
         # Check if framerate is in metadata. If not, set to 60
-        if 'framerate' not in existingMeta:
-            framerate = 60
-        else:
-            framerate = existingMeta['framerate']
+        framerate = existingMeta.get('settings', {}).get(
+            'framerate', existingMeta.get('framerate', 60))
         if 'filterfrequency' in newMetaDict:
             if newMetaDict['filterfrequency'] != 'default':
                 if float(newMetaDict['filterfrequency']) > framerate/2:
@@ -2121,4 +2119,3 @@ def makeRequestWithRetry(method, url,
                                     files=files)
     response.raise_for_status()
     return response
-


### PR DESCRIPTION
fix for #216. Should now accurately get the frame rate. With more tests to add to utils test file